### PR TITLE
feat: 장바구니 주문 기능 구현

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -186,6 +186,13 @@ app.get('/orders', (req, res) => {
   res.json(orders);
 });
 
+app.post('/orders', (req, res) => {
+  const newOrder = req.body;
+  orders.push(newOrder);
+  cart = [];
+  res.json({ message: '주문이 저장되었습니다!', order: newOrder });
+});
+
 //Listen for connections.
 app.listen(port, () => {
   console.log('3000번 포트에서 backend server 실행중...');

--- a/renderCarts_Order.js
+++ b/renderCarts_Order.js
@@ -47,6 +47,7 @@ function order() {
     .then((response) => response.json())
     .then((data) => {
       alert(data.message);
+      cartData = [];
       window.location.href = 'orderList.html';
     })
     .catch((error) => {

--- a/renderCarts_Order.js
+++ b/renderCarts_Order.js
@@ -27,3 +27,31 @@ function renderCarts() {
       });
     });
 }
+
+function order() {
+  if (cartData.length === 0) {
+    alert('장바구니가 비어 있습니다.');
+    return;
+  }
+  const orderData = {
+    orderId: Math.floor(Math.random() * 100) + 1, // 주문 ID (랜덤으로 생성)
+    date: new Date().toISOString().split('T')[0], // 주문 일자 (오늘 날짜)
+    items: cartData, // 장바구니 데이터
+  };
+
+  fetch('http://localhost:3000/orders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(orderData),
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      alert(data.message);
+      window.location.href = 'orderList.html';
+    })
+    .catch((error) => {
+      console.error('주문 오류:', error);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', renderCarts);


### PR DESCRIPTION
close #6 

✅ 구현 내용

1. 장바구니 전체 주문 기능 구현

- 장바구니가 비어 있을 경우, "장바구니가 비어 있습니다."라는 알림 메시지를 표시합니다.
- 주문 시, 랜덤한 주문 ID와 현재 날짜를 포함한 주문 데이터를 생성합니다.
- fetch를 사용하여 서버로 주문 데이터를 전송합니다.
- 주문 완료 후, orderList.html 페이지로 이동하도록 설정했습니다.
- 주문이 완료되면 장바구니 데이터를 초기화합니다.

✅ 구현 화면
![image](https://github.com/user-attachments/assets/2299eb12-7627-4477-8a6d-2bfc9af4fe57)

+ 선택 상품 주문, 장바구니 항목 삭제는 추후 추가 예정